### PR TITLE
Fix forwarding stall in tcpfwd

### DIFF
--- a/src/proxy_conn.h
+++ b/src/proxy_conn.h
@@ -15,7 +15,6 @@ enum proxy_state {
     S_INITIAL = 0,
     S_CONNECTING,
     S_SERVER_CONNECTING,
-    S_SERVER_CONNECTED,
     S_FORWARDING,
     S_CLOSING,
 };


### PR DESCRIPTION
## Summary
- transition directly to forwarding once the server socket connects
- flush any client data buffered during connect and fall back to user-space forwarding
- drop unused server-connected state and simplify event loop

## Testing
- `make`
- `python3 - <<'PY'
import socket
s=socket.socket(); s.connect(('127.0.0.1',9003)); s.sendall(b'hello'); data=s.recv(1024); print('received', data); s.close()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac9bdab658832aa9bbd5179dd3b7b4
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a stall in tcpfwd where connections could hang after the server connect finished, especially when the client sent data during connect. We now start forwarding immediately and flush any buffered client data to prevent no-response cases.

- **Bug Fixes**
  - Enter S_FORWARDING as soon as connect() succeeds; removed S_SERVER_CONNECTED.
  - If client data was buffered during connect, disable splice to flush via user-space first.
  - Simplified event loop: handle_server_connecting now invokes handle_forwarding with the current epoll event.

<!-- End of auto-generated description by cubic. -->

