### PR TITLE
Use fixed-width types for event tags and size-aware allocation

### DIFF
--- a/src/proxy_conn.h
+++ b/src/proxy_conn.h
@@ -2,6 +2,7 @@
 #define __PORTFWD_PROXY_CONN_H__
 
 #include "list.h"
+#include <stdint.h>
 
 /* Shared buffer structure */
 struct buffer_info {
@@ -32,8 +33,8 @@ struct proxy_conn {
     struct buffer_info request;  /* client -> server */
     struct buffer_info response; /* server -> client */
 
-    int magic_client;
-    int magic_server;
+    uint32_t magic_client;
+    uint32_t magic_server;
 
     bool use_splice;
     size_t splice_pending;

--- a/src/udpfwd.c
+++ b/src/udpfwd.c
@@ -117,7 +117,8 @@ static void destroy_batching_resources(
 static int init_conn_pool(void)
 {
     g_conn_pool.capacity = UDP_PROXY_MAX_CONNS;
-    g_conn_pool.connections = malloc(sizeof(struct proxy_conn) * g_conn_pool.capacity);
+    g_conn_pool.connections = malloc(sizeof(struct proxy_conn) *
+                                     (size_t)g_conn_pool.capacity);
     if (!g_conn_pool.connections) {
         P_LOG_ERR("Failed to allocate connection pool");
         return -1;


### PR DESCRIPTION
## Summary
- enforce fixed-width `uint32_t` identifiers for epoll event tags
- avoid signed overflow by casting connection counts to `size_t` during allocation

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68ad360b44d0832a96756582749c8a53
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardizes epoll event tags to uint32_t for clear, predictable behavior. Also prevents potential signed overflow by using size-aware allocation for connection pools.

- **Refactors**
  - Use uint32_t for magic tags; add U suffix to constants and include stdint.h.
  - Update ev->data.ptr comparisons and magic_listener type to match the new tag type.

- **Bug Fixes**
  - Allocate TCP/UDP connection pools with size_t-cast counts to avoid signed overflow.

<!-- End of auto-generated description by cubic. -->

