### PR TITLE
Improve client cleanup and buffer safety

### DIFF
--- a/src/kcptcp_client.c
+++ b/src/kcptcp_client.c
@@ -61,6 +61,9 @@ static void client_handle_tcp_events(struct client_ctx *ctx,
 /* UDP socket events for a single connection */
 static void client_handle_udp_events(struct client_ctx *ctx,
                                      struct proxy_conn *c, uint32_t evmask) {
+    if (c->state == S_CLOSING)
+        return;
+
     if (!(evmask & EPOLLIN)) {
         return;
     }
@@ -132,6 +135,18 @@ static void client_handle_udp_events(struct client_ctx *ctx,
                     c->rekey_in_progress = false;
                 } else {
                     P_LOG_ERR("session key derivation failed");
+                    if (c->request.data) {
+                        free(c->request.data);
+                        c->request.data = NULL;
+                        c->request.capacity = c->request.dlen =
+                            c->request.rpos = 0;
+                    }
+                    if (c->response.data) {
+                        free(c->response.data);
+                        c->response.data = NULL;
+                        c->response.capacity = c->response.dlen =
+                            c->response.rpos = 0;
+                    }
                     c->state = S_CLOSING;
                     break;
                 }
@@ -229,11 +244,19 @@ static void client_handle_udp_events(struct client_ctx *ctx,
                                                MAX_TCP_BUFFER_SIZE)) {
                             P_LOG_WARN("Response buffer size limit exceeded, "
                                        "closing connection");
+                            free(c->response.data);
+                            c->response.data = NULL;
+                            c->response.capacity = c->response.dlen =
+                                c->response.rpos = 0;
                             c->state = S_CLOSING;
                             break;
                         }
                         char *np = (char *)realloc(c->response.data, ncap);
                         if (!np) {
+                            free(c->response.data);
+                            c->response.data = NULL;
+                            c->response.capacity = c->response.dlen =
+                                c->response.rpos = 0;
                             c->state = S_CLOSING;
                             break;
                         }
@@ -268,11 +291,19 @@ static void client_handle_udp_events(struct client_ctx *ctx,
                                            MAX_TCP_BUFFER_SIZE)) {
                         P_LOG_WARN("Response buffer size limit exceeded, "
                                    "closing connection");
+                        free(c->response.data);
+                        c->response.data = NULL;
+                        c->response.capacity = c->response.dlen =
+                            c->response.rpos = 0;
                         c->state = S_CLOSING;
                         break;
                     }
                     char *np = (char *)realloc(c->response.data, ncap);
                     if (!np) {
+                        free(c->response.data);
+                        c->response.data = NULL;
+                        c->response.capacity = c->response.dlen =
+                            c->response.rpos = 0;
                         c->state = S_CLOSING;
                         break;
                     }
@@ -338,8 +369,10 @@ static void client_handle_accept(struct client_ctx *ctx) {
         /* Generate 16-byte token using cryptographically secure random */
         if (secure_random_bytes(c->hs_token, 16) != 0) {
             P_LOG_ERR("Failed to generate secure random token");
-            c->state = S_CLOSING;
-            break;
+            close(cs);
+            close(us);
+            free(c);
+            continue;
         }
         /* Send HELLO: [type][ver][token(16)] */
         unsigned char hbuf[1 + 1 + 16];
@@ -407,6 +440,9 @@ static void client_handle_accept(struct client_ctx *ctx) {
 /* TCP client socket events for a single connection */
 static void client_handle_tcp_events(struct client_ctx *ctx,
                                      struct proxy_conn *c, uint32_t evmask) {
+    if (c->state == S_CLOSING)
+        return;
+
     if (evmask & (EPOLLERR | EPOLLHUP)) {
         c->state = S_CLOSING;
     }
@@ -467,11 +503,19 @@ static void client_handle_tcp_events(struct client_ctx *ctx,
                                            MAX_TCP_BUFFER_SIZE)) {
                         P_LOG_WARN("Request buffer size limit exceeded, "
                                    "closing connection");
+                        free(c->request.data);
+                        c->request.data = NULL;
+                        c->request.capacity = c->request.dlen =
+                            c->request.rpos = 0;
                         c->state = S_CLOSING;
                         break;
                     }
                     char *np = (char *)realloc(c->request.data, ncap);
                     if (!np) {
+                        free(c->request.data);
+                        c->request.data = NULL;
+                        c->request.capacity = c->request.dlen =
+                            c->request.rpos = 0;
                         c->state = S_CLOSING;
                         break;
                     }


### PR DESCRIPTION
## Summary
- avoid processing UDP/TCP events when connection is closing to prevent races
- release buffered data and mark connection closing on session key failure
- free buffers on allocation failure and clean up handshake resources

## Testing
- `make build`
- `make kcptcp-client`


------
https://chatgpt.com/codex/tasks/task_e_68b14d4bad08832ab5e52e0be833892b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improves client memory and resource safety to prevent races, leaks, and buffer misuse. Skips event handling for closing connections and cleans up buffers and sockets on failures.

- **Bug Fixes**
  - Ignore UDP/TCP events when the connection is in S_CLOSING to avoid races.
  - On session key derivation failure, free request/response buffers and mark connection closing.
  - Enforce MAX_TCP_BUFFER_SIZE; on overflow or realloc failure, free and null buffers, then close.
  - On handshake token generation failure, close sockets and free the connection to avoid leaks.
  - After freeing buffers, reset capacity/dlen/rpos to 0 to prevent use-after-free.

<!-- End of auto-generated description by cubic. -->

