### PR TITLE
Refresh timestamp cache while processing UDP batches

### DIFF
--- a/doc/udpfwd_hang_analysis.md
+++ b/doc/udpfwd_hang_analysis.md
@@ -1,0 +1,16 @@
+# udpfwd hang analysis
+
+## Summary
+While reviewing `src/udpfwd.c` to diagnose the long-running hang that appears after the proxy has been forwarding traffic for several minutes, I noticed that the cached timestamp (`g_now_ts`) used to drive connection expiration is updated in the wrong place. The main event loop writes the current monotonic time into `g_now_ts` **before** it goes to sleep in `epoll_wait()`. Functions that mark a connection as active, such as `touch_proxy_conn()`, read that cached value and store it in `conn->last_active`. As a result, every datagram handled during one pass through the event loop receives the timestamp that was recorded *before* the call to `epoll_wait()`.
+
+If the loop then blocks in `epoll_wait()` for a long period (for example because only a trickle of traffic arrives), the cached time lags behind the real time by the entire sleep duration. When the maintenance pass runs, `proxy_conn_walk_continue()` compares the fresh current time with the stale `conn->last_active`, computes a large idle duration, and tears the mapping down even though the flow is still active. Once the mapping disappears, datagrams sent by the client no longer find an existing `proxy_conn`, the forwarding socket is recreated, and the remote peer sees traffic coming from a different 5-tuple. That looks like the proxy has frozen until the application-level protocol restarts.
+
+### Key locations
+- The cached timestamp is recorded before blocking in `epoll_wait()`.【F:src/udpfwd.c†L1692-L1716】
+- `touch_proxy_conn()` copies that cached timestamp into `conn->last_active` for every packet we forward, so it inherits the stale value.【F:src/udpfwd.c†L775-L788】
+- The LRU reaper uses `cached_now_seconds()` (which simply returns `g_now_ts`) to decide which connections are idle and should be dropped.【F:src/udpfwd.c†L1025-L1066】
+
+Because the timestamp cache is only refreshed *before* the blocking wait, the timeout calculation can drift by multiple seconds (or even minutes if the loop keeps processing other fds) and eventually exceeds the configured timeout. At that point the proxy releases otherwise healthy sessions, and UDP forwarding appears to hang from the user's perspective.
+
+## Suggested direction
+Move the `atomic_store(&g_now_ts, current_ts);` call so that it runs **after** `epoll_wait()` returns with events, or refresh the cached time again immediately before calling `touch_proxy_conn()`. That way the activity timestamps track the real arrival time of packets and the timeout walker no longer evicts live flows.

--- a/src/udpfwd.c
+++ b/src/udpfwd.c
@@ -317,6 +317,7 @@ static inline time_t cached_now_seconds(void) {
     time_t now = atomic_load(&g_now_ts);
     if (now == 0) {
         now = monotonic_seconds();
+        atomic_store(&g_now_ts, now);
     }
     return now;
 }
@@ -1119,6 +1120,8 @@ static void handle_client_data(int lsn_sock, int epfd) {
                 break;
             }
 
+            atomic_store(&g_now_ts, monotonic_seconds());
+
             for (int i = 0; i < n; i++) {
                 union sockaddr_inx *sa = (union sockaddr_inx *)c_msgs[i].msg_hdr.msg_name;
                 size_t packet_len = c_msgs[i].msg_len;
@@ -1173,6 +1176,8 @@ static void handle_client_data(int lsn_sock, int epfd) {
             log_if_unexpected_errno("recvfrom()");
         return;
     }
+
+    atomic_store(&g_now_ts, monotonic_seconds());
 
     if (!validate_packet(buffer, (size_t)r, &cli_addr))
         return;
@@ -1247,6 +1252,8 @@ static void handle_server_data(struct proxy_conn *conn, int lsn_sock, int epfd) 
             return;
         }
 
+        atomic_store(&g_now_ts, monotonic_seconds());
+
         /* Prepare destination (original client) for each message */
         /* All packets are for the same connection, so touch it only once per batch. */
         touch_proxy_conn(conn);
@@ -1302,6 +1309,7 @@ static void handle_server_data(struct proxy_conn *conn, int lsn_sock, int epfd) 
         }
 
         /* r >= 0: forward even zero-length datagrams */
+        atomic_store(&g_now_ts, monotonic_seconds());
         touch_proxy_conn(conn);
 
         ssize_t wr = sendto(lsn_sock, buffer, r, 0, (struct sockaddr *)&conn->cli_addr,
@@ -1691,6 +1699,10 @@ int main(int argc, char *argv[]) {
         int nfds;
         time_t current_ts = monotonic_seconds();
 
+        /* Refresh cached timestamp immediately so maintenance passes see the
+         * up-to-date wall clock. */
+        atomic_store(&g_now_ts, current_ts);
+
         /* Periodic timeout check and connection recycling */
         if ((long)(current_ts - last_check) >= MAINT_INTERVAL_SEC) {
             proxy_conn_walk_continue(epfd);
@@ -1705,20 +1717,21 @@ int main(int argc, char *argv[]) {
                 break;
         }
 
-        /* Cache current timestamp for hot paths - atomic update */
-        atomic_store(&g_now_ts, current_ts);
-
         /* Check shutdown flag before blocking */
         if (g_shutdown_requested)
             break;
 
         /* Wait for events */
         nfds = epoll_wait(epfd, events, countof(events), EPOLL_WAIT_TIMEOUT_MS);
-        
+
+        /* Update cached timestamp for event handlers regardless of wait result. */
+        current_ts = monotonic_seconds();
+        atomic_store(&g_now_ts, current_ts);
+
         /* Check shutdown flag after epoll_wait (handles timeout and EINTR cases) */
         if (g_shutdown_requested)
             break;
-        
+
         if (nfds == 0)
             continue; /* Timeout, loop back to check shutdown flag */
         if (nfds < 0) {


### PR DESCRIPTION
## Summary
- store the monotonic time back into the cached timestamp the first time it is read
- refresh the cached timestamp whenever client or server batches are drained so long processing loops keep activity timestamps current

## Testing
- make -C src udpfwd

------
https://chatgpt.com/codex/tasks/task_e_68eb2c6d93d0832ab6731251c3006237
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the UDP forward “freeze” by keeping the cached timestamp fresh during event-loop waits and batch processing so active flows aren’t reaped by mistake.

- **Bug Fixes**
  - Write monotonic time back into g_now_ts on first read.
  - Refresh g_now_ts after epoll_wait and when draining client/server batches.
  - Add udpfwd hang analysis doc to explain the root cause and fix.

<!-- End of auto-generated description by cubic. -->

