### PR TITLE
Handle UDP send backpressure without freezing

### DIFF
--- a/src/proxy_conn.h
+++ b/src/proxy_conn.h
@@ -66,6 +66,7 @@ struct proxy_conn {
     time_t last_addr_warn; /* Last time we warned about unexpected UDP source */
     struct list_head lru;  /* LRU linkage: oldest at head, newest at tail */
     bool needs_lru_update;  /* Deferred LRU touch flag */
+    bool udp_send_blocked;  /* True when EPOLLOUT interest is armed */
 
     /* Statistics (always enabled for diagnostics) */
     unsigned long client_packets;  /* Packets received from client */


### PR DESCRIPTION
## Summary
- explain root cause and fix backlog and epoll modifications

## Testing
- make -C src udpfwd

------
https://chatgpt.com/codex/tasks/task_e_68ed270447c0832a8c79b8d5616320cd
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents UDP forwarding from freezing under send backpressure by buffering datagrams and toggling EPOLLOUT to flush when the server socket becomes writable. Keeps connections responsive with a small, bounded backlog and better epoll handling.

- **Bug Fixes**
  - Buffer UDP datagrams when send would block, using a length-prefixed backlog; drop oversized frames.
  - Arm/disarm EPOLLOUT based on backlog state (udp_send_blocked) and flush up to 16 queued packets when writable.
  - Handle EINTR on send and validate backlog entries; free/reset backlog on connection release.
  - Register server sockets with EPOLLERR/HUP and process EPOLLOUT in the main loop to resume sending without freezing.

<!-- End of auto-generated description by cubic. -->

